### PR TITLE
Query /etc/os-release for distro id

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME="NodeMCU-Linux"
 DATE=`date +%F`
-DEBIAN=$(shell uname -a | grep -qi raspberry && echo "raspbian" || echo "pure")
+DEBIAN=$(shell grep -qi 'id\s*=\s*raspbian' /etc/os-release && echo "raspbian" || echo "pure")
 
 all::
 	@echo "make requirements install deinstall backup"


### PR DESCRIPTION
`uname` doesn't provide distro info, just the hostname.
Distro identification is available from `/etc/os-release` on all of my systems (raspbian, debian, lede, opensuse).
